### PR TITLE
fix: Replace localhost name with the result of window.location.hostname

### DIFF
--- a/core/config/config.js
+++ b/core/config/config.js
@@ -6,7 +6,7 @@ import { BLOCKS } from './blockDict'
 const Config = {
   tech: {
     maxWorkerCount: 4,
-    socketEndpoint: 'localhost:5000'
+    socketEndpoint: `${self.location.hostname}:5000`
   },
   lights: {
     sunlight: {

--- a/core/modules/interfaces/connectionStatus/connectionStatus.js
+++ b/core/modules/interfaces/connectionStatus/connectionStatus.js
@@ -5,7 +5,8 @@ import classes from './connectionStatus.module.css'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 
 function ConnectionStatus(container) {
-  const subscriptionClient = new SubscriptionClient(`ws://localhost:4000`, {
+  const { hostname } = window.location
+  const subscriptionClient = new SubscriptionClient(`ws://${hostname}:4000`, {
     reconnect: true
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,9 @@ import { ApolloProvider } from '@apollo/react-hooks'
 
 dotenv.config()
 
+const { hostname } = window.location
 const httpLink = createHttpLink({
-  uri: 'http://localhost:4000',
+  uri: `http://${hostname}:4000`,
   credentials: 'same-origin'
 })
 
@@ -28,7 +29,7 @@ const link = split(
     return kind === 'OperationDefinition' && operation === 'subscription'
   },
   new WebSocketLink({
-    uri: 'ws://localhost:4000',
+    uri: `ws://${hostname}:4000`,
     options: {
       reconnect: true
     }


### PR DESCRIPTION
This PR replaces the `localhost` string with the hostname from `window.location.hostname` in config files. It's helpful for anyone to use two machines with different domain names to develop and run backend.