### PR TITLE
Fix createPlayer

### DIFF
--- a/server/src/schema/api/world.graphql
+++ b/server/src/schema/api/world.graphql
@@ -1,0 +1,7 @@
+type Mutation {
+  joinWorld(where: WorldWhereUniqueInput!, data: JoinWorldDataInput!): Player
+}
+
+input JoinWorldDataInput {
+  gamemode: Gamemode = "CREATIVE"
+}

--- a/src/lib/graphql/mutations.js
+++ b/src/lib/graphql/mutations.js
@@ -42,7 +42,9 @@ export const CREATE_WORLD_MUTATION = gql`
 
 export const CREATE_PLAYER_MUTATION = gql`
   mutation CreatePlayer($gamemode: Gamemode!, $worldId: ID!) {
-    createPlayer(data: { gamemode: $gamemode, worldId: $worldId })
+    joinWorld(data: { gamemode: $gamemode }, where: { id: $worldId }) {
+      id
+    }
   }
 `
 


### PR DESCRIPTION
Native PlayerCreateInput have many required fields.
![joxi_screenshot_1566030347926](https://user-images.githubusercontent.com/2550668/63208830-e0035480-c0e1-11e9-831c-672cb0a2c4cd.png)

New joinWorld catch only custom fields.
![joxi_screenshot_1566030506098](https://user-images.githubusercontent.com/2550668/63208861-52743480-c0e2-11e9-818a-208631a61b89.png)
